### PR TITLE
Feat: 회고뷰 Coredata 활용한 CRUD 기능 구현 

### DIFF
--- a/COMFIE.xcodeproj/project.pbxproj
+++ b/COMFIE.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		51F8F5C32D952B4B00DD2E3D /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F8F5C22D952B4B00DD2E3D /* UINavigationController+.swift */; };
 		51F8F5C42D952B4B00DD2E3D /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F8F5C22D952B4B00DD2E3D /* UINavigationController+.swift */; };
 		51F8F5C52D952B4B00DD2E3D /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F8F5C22D952B4B00DD2E3D /* UINavigationController+.swift */; };
+		B95C98C12DAC9FEB0057C868 /* Memo+with.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95C98C02DAC9FE70057C868 /* Memo+with.swift */; };
 		B96CDB302DA235B5004EA2E9 /* RetrospectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96CDB2F2DA235B1004EA2E9 /* RetrospectionView.swift */; };
 		B96CDB322DA236B1004EA2E9 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96CDB312DA236B0004EA2E9 /* Date+.swift */; };
 		B96CDB332DA236B1004EA2E9 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96CDB312DA236B0004EA2E9 /* Date+.swift */; };
@@ -235,6 +236,7 @@
 		51F8F5B52D95259300DD2E3D /* CFNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CFNavigationBar.swift; sourceTree = "<group>"; };
 		51F8F5BE2D9529B600DD2E3D /* View+cfNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+cfNavigationBar.swift"; sourceTree = "<group>"; };
 		51F8F5C22D952B4B00DD2E3D /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
+		B95C98C02DAC9FE70057C868 /* Memo+with.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Memo+with.swift"; sourceTree = "<group>"; };
 		B96CDB2F2DA235B1004EA2E9 /* RetrospectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectionView.swift; sourceTree = "<group>"; };
 		B96CDB312DA236B0004EA2E9 /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		B96CDB392DA238E7004EA2E9 /* EdgeInsets+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EdgeInsets+.swift"; sourceTree = "<group>"; };
@@ -311,6 +313,7 @@
 		26D697B42D7F2DCE00AC200C /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B95C98C02DAC9FE70057C868 /* Memo+with.swift */,
 				26D697B52D7F2DDF00AC200C /* Memo+toEntity.swift */,
 				26D697B72D7F2DEF00AC200C /* ComfieZone+toEntity.swift */,
 				26D697B92D7F3D4700AC200C /* Memo+fromEntity.swift */,
@@ -910,6 +913,7 @@
 				510341112D7989B00050C718 /* LoadingView.swift in Sources */,
 				267F6B5B2D9CEBEB0089BD6D /* MockMemoRepository.swift in Sources */,
 				B9EA53002D7C907E00A32305 /* View+ComfieFonts.swift in Sources */,
+				B95C98C12DAC9FEB0057C868 /* Memo+with.swift in Sources */,
 				510341252D79A58B0050C718 /* UserDefaultsService.swift in Sources */,
 				51D882E42DAFF4150072E3C0 /* LocalAuthenticationService.swift in Sources */,
 				517FCAC52D7AB31100A250A3 /* ComfieZone.swift in Sources */,

--- a/COMFIE.xcodeproj/project.pbxproj
+++ b/COMFIE.xcodeproj/project.pbxproj
@@ -120,7 +120,7 @@
 		B96CDB3F2DA23D3F004EA2E9 /* StringLiterals+Retrospection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96CDB3D2DA23D36004EA2E9 /* StringLiterals+Retrospection.swift */; };
 		B96CDB402DA23D3F004EA2E9 /* StringLiterals+Retrospection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96CDB3D2DA23D36004EA2E9 /* StringLiterals+Retrospection.swift */; };
 		B96CDB422DA240B2004EA2E9 /* RetrospectionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96CDB412DA240AC004EA2E9 /* RetrospectionStore.swift */; };
-		B99A081C2DABABA80094EECB /* RetrospectionRepsitoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99A081B2DABAB9E0094EECB /* RetrospectionRepsitoryProtocol.swift */; };
+		B99A081C2DABABA80094EECB /* RetrospectionRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99A081B2DABAB9E0094EECB /* RetrospectionRepositoryProtocol.swift */; };
 		B99A081E2DABAD410094EECB /* RetrospectionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99A081D2DABAD390094EECB /* RetrospectionRepository.swift */; };
 		B9EA52F52D7C8F8A00A32305 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = B9EA52F42D7C8F8A00A32305 /* Pretendard-Regular.otf */; };
 		B9EA52F62D7C8F8A00A32305 /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = B9EA52F22D7C8F8A00A32305 /* Pretendard-Bold.otf */; };
@@ -242,7 +242,7 @@
 		B96CDB392DA238E7004EA2E9 /* EdgeInsets+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EdgeInsets+.swift"; sourceTree = "<group>"; };
 		B96CDB3D2DA23D36004EA2E9 /* StringLiterals+Retrospection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StringLiterals+Retrospection.swift"; sourceTree = "<group>"; };
 		B96CDB412DA240AC004EA2E9 /* RetrospectionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectionStore.swift; sourceTree = "<group>"; };
-		B99A081B2DABAB9E0094EECB /* RetrospectionRepsitoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectionRepsitoryProtocol.swift; sourceTree = "<group>"; };
+		B99A081B2DABAB9E0094EECB /* RetrospectionRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectionRepositoryProtocol.swift; sourceTree = "<group>"; };
 		B99A081D2DABAD390094EECB /* RetrospectionRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectionRepository.swift; sourceTree = "<group>"; };
 		B9EA52F22D7C8F8A00A32305 /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
 		B9EA52F32D7C8F8A00A32305 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
@@ -618,7 +618,7 @@
 			isa = PBXGroup;
 			children = (
 				B99A081D2DABAD390094EECB /* RetrospectionRepository.swift */,
-				B99A081B2DABAB9E0094EECB /* RetrospectionRepsitoryProtocol.swift */,
+				B99A081B2DABAB9E0094EECB /* RetrospectionRepositoryProtocol.swift */,
 			);
 			path = RetrospectionRepository;
 			sourceTree = "<group>";
@@ -904,7 +904,7 @@
 				51A7AFF72D809DD600B50D1E /* LocalizedStringResource+localized.swift in Sources */,
 				B9EA53112D7CA5DC00A32305 /* StringLiterals.swift in Sources */,
 				267F6B3F2D94F11A0089BD6D /* Date+.swift in Sources */,
-				B99A081C2DABABA80094EECB /* RetrospectionRepsitoryProtocol.swift in Sources */,
+				B99A081C2DABABA80094EECB /* RetrospectionRepositoryProtocol.swift in Sources */,
 				510340F82D777C260050C718 /* COMFIEApp.swift in Sources */,
 				51895AF62DA8FBF500AFA569 /* MakersView.swift in Sources */,
 				51F8F5B02D91ACF000DD2E3D /* StringLiterals_Onboarding.swift in Sources */,

--- a/COMFIE.xcodeproj/project.pbxproj
+++ b/COMFIE.xcodeproj/project.pbxproj
@@ -119,6 +119,8 @@
 		B96CDB3F2DA23D3F004EA2E9 /* StringLiterals+Retrospection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96CDB3D2DA23D36004EA2E9 /* StringLiterals+Retrospection.swift */; };
 		B96CDB402DA23D3F004EA2E9 /* StringLiterals+Retrospection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96CDB3D2DA23D36004EA2E9 /* StringLiterals+Retrospection.swift */; };
 		B96CDB422DA240B2004EA2E9 /* RetrospectionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96CDB412DA240AC004EA2E9 /* RetrospectionStore.swift */; };
+		B99A081C2DABABA80094EECB /* RetrospectionRepsitoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99A081B2DABAB9E0094EECB /* RetrospectionRepsitoryProtocol.swift */; };
+		B99A081E2DABAD410094EECB /* RetrospectionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99A081D2DABAD390094EECB /* RetrospectionRepository.swift */; };
 		B9EA52F52D7C8F8A00A32305 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = B9EA52F42D7C8F8A00A32305 /* Pretendard-Regular.otf */; };
 		B9EA52F62D7C8F8A00A32305 /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = B9EA52F22D7C8F8A00A32305 /* Pretendard-Bold.otf */; };
 		B9EA52F72D7C8F8A00A32305 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = B9EA52F32D7C8F8A00A32305 /* Pretendard-Medium.otf */; };
@@ -238,6 +240,8 @@
 		B96CDB392DA238E7004EA2E9 /* EdgeInsets+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EdgeInsets+.swift"; sourceTree = "<group>"; };
 		B96CDB3D2DA23D36004EA2E9 /* StringLiterals+Retrospection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StringLiterals+Retrospection.swift"; sourceTree = "<group>"; };
 		B96CDB412DA240AC004EA2E9 /* RetrospectionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectionStore.swift; sourceTree = "<group>"; };
+		B99A081B2DABAB9E0094EECB /* RetrospectionRepsitoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectionRepsitoryProtocol.swift; sourceTree = "<group>"; };
+		B99A081D2DABAD390094EECB /* RetrospectionRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrospectionRepository.swift; sourceTree = "<group>"; };
 		B9EA52F22D7C8F8A00A32305 /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
 		B9EA52F32D7C8F8A00A32305 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
 		B9EA52F42D7C8F8A00A32305 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
@@ -276,6 +280,7 @@
 		267F6B4B2D969F4B0089BD6D /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				B99A081A2DABAB910094EECB /* RetrospectionRepository */,
 				267F6B5C2D9CEF7C0089BD6D /* MemoRepository */,
 			);
 			path = Repository;
@@ -606,6 +611,15 @@
 			path = Retrospection;
 			sourceTree = "<group>";
 		};
+		B99A081A2DABAB910094EECB /* RetrospectionRepository */ = {
+			isa = PBXGroup;
+			children = (
+				B99A081D2DABAD390094EECB /* RetrospectionRepository.swift */,
+				B99A081B2DABAB9E0094EECB /* RetrospectionRepsitoryProtocol.swift */,
+			);
+			path = RetrospectionRepository;
+			sourceTree = "<group>";
+		};
 		B9EA52F12D7C8F4F00A32305 /* Fonts */ = {
 			isa = PBXGroup;
 			children = (
@@ -880,12 +894,14 @@
 				517FCAC32D7AB2B100A250A3 /* Memo.swift in Sources */,
 				51F8F5B72D95259300DD2E3D /* CFNavigationBar.swift in Sources */,
 				26D697B32D7EE39E00AC200C /* CoreDataService.swift in Sources */,
+				B99A081E2DABAD410094EECB /* RetrospectionRepository.swift in Sources */,
 				B96CDB422DA240B2004EA2E9 /* RetrospectionStore.swift in Sources */,
 				510341162D7993D60050C718 /* Route.swift in Sources */,
 				B96CDB302DA235B5004EA2E9 /* RetrospectionView.swift in Sources */,
 				51A7AFF72D809DD600B50D1E /* LocalizedStringResource+localized.swift in Sources */,
 				B9EA53112D7CA5DC00A32305 /* StringLiterals.swift in Sources */,
 				267F6B3F2D94F11A0089BD6D /* Date+.swift in Sources */,
+				B99A081C2DABABA80094EECB /* RetrospectionRepsitoryProtocol.swift in Sources */,
 				510340F82D777C260050C718 /* COMFIEApp.swift in Sources */,
 				51895AF62DA8FBF500AFA569 /* MakersView.swift in Sources */,
 				51F8F5B02D91ACF000DD2E3D /* StringLiterals_Onboarding.swift in Sources */,

--- a/COMFIE/App/DIContainer/DIContainer.swift
+++ b/COMFIE/App/DIContainer/DIContainer.swift
@@ -27,7 +27,9 @@ struct DIContainer {
         ComfieZoneSettingStore(popupIntent: makeComfieZoneSettingPopupIntent())
     }
     
-    private func makeRetrospectionIntent() -> RetrospectionStore { RetrospectionStore(router: router) }
+    private func makeRetrospectionIntent(memo: Memo) -> RetrospectionStore {
+        RetrospectionStore(router: router, memo: memo)
+    }
     private func makeMoreIntent() -> MoreStore { MoreStore(router: router) }
     
     // MARK: - View
@@ -40,8 +42,8 @@ struct DIContainer {
             OnboardingView(intent: makeOnboardingIntent())
         case .memo:
             MemoView(intent: makeMemoIntent())
-        case .retrospection:
-            RetrospectionView(intent: makeRetrospectionIntent())
+        case .retrospection(let memo):
+            RetrospectionView(intent: makeRetrospectionIntent(memo: memo))
         case .comfieZoneSetting:
             ComfieZoneSettingView(intent: makeComfieZoneSettingIntent())
         case .more:

--- a/COMFIE/App/DIContainer/DIContainer.swift
+++ b/COMFIE/App/DIContainer/DIContainer.swift
@@ -12,7 +12,7 @@ struct DIContainer {
     
     // MARK: - Repository
     let memoRepository: MemoRepositoryProtocol = MemoRepository()
-    let retrospectionRepository: RetrospectionRepsitoryProtocol = RetrospectionRepository()
+    let retrospectionRepository: RetrospectionRepositoryProtocol = RetrospectionRepository()
     
     // MARK: - Intent
     private func makeOnboardingIntent() -> OnboardingStore { OnboardingStore(router: router) }

--- a/COMFIE/App/DIContainer/DIContainer.swift
+++ b/COMFIE/App/DIContainer/DIContainer.swift
@@ -12,6 +12,7 @@ struct DIContainer {
     
     // MARK: - Repository
     let memoRepository: MemoRepositoryProtocol = MemoRepository()
+    let retrospectionRepository: RetrospectionRepsitoryProtocol = RetrospectionRepository()
     
     // MARK: - Intent
     private func makeOnboardingIntent() -> OnboardingStore { OnboardingStore(router: router) }
@@ -28,7 +29,7 @@ struct DIContainer {
     }
     
     private func makeRetrospectionIntent(memo: Memo) -> RetrospectionStore {
-        RetrospectionStore(router: router, memo: memo)
+        RetrospectionStore(router: router, repository: retrospectionRepository, memo: memo)
     }
     private func makeMoreIntent() -> MoreStore { MoreStore(router: router) }
     

--- a/COMFIE/App/Router/Route.swift
+++ b/COMFIE/App/Router/Route.swift
@@ -8,12 +8,12 @@
 import SwiftUI
 
 // Navigation으로 이동하는 경로
-enum Route {
+enum Route: Hashable {
     // MARK: - 메인 화면
     case loading
     case onboarding
     case memo
-    case retrospection
+    case retrospection(memo: Memo)
     case comfieZoneSetting
     case more
     

--- a/COMFIE/Data/CoreData/CoreDataService.swift
+++ b/COMFIE/Data/CoreData/CoreDataService.swift
@@ -68,6 +68,7 @@ extension CoreDataService {
     func saveRetrospection(_ memo: Memo) -> Result<Void, Error> {
         let request: NSFetchRequest<MemoEntity> = MemoEntity.fetchRequest()
         request.predicate = NSPredicate(format: "id == %@", memo.id as CVarArg)
+        request.fetchLimit = 1
         
         do {
             if let entity = try context.fetch(request).first {

--- a/COMFIE/Data/CoreData/CoreDataService.swift
+++ b/COMFIE/Data/CoreData/CoreDataService.swift
@@ -64,6 +64,23 @@ extension CoreDataService {
             return .failure(error)
         }
     }
+    
+    func saveRetrospection(_ memo: Memo) -> Result<Void, Error> {
+        let request: NSFetchRequest<MemoEntity> = MemoEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", memo.id as CVarArg)
+        
+        do {
+            if let entity = try context.fetch(request).first {
+                entity.retrospectionText = memo.retrospectionText
+                try context.save()
+                return .success(())
+            } else {
+                return .failure(NSError(domain: "MemoNotFound", code: 404, userInfo: nil))
+            }
+        } catch {
+            return .failure(error)
+        }
+    }
 }
 
 // MARK: - READ
@@ -173,6 +190,23 @@ extension CoreDataService {
             print("All comfieZone records deleted successfully.")
         } catch {
             print("Failed to delete all comfieZone records: \(error)")
+        }
+    }
+    
+    func deleteRetrospectionText(for memo: Memo) -> Result<Void, Error> {
+        let request = MemoEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", memo.id as CVarArg)
+        
+        do {
+            if let entity = try context.fetch(request).first {
+                entity.retrospectionText = nil
+                try context.save()
+                return .success(())
+            } else {
+                return .failure(NSError(domain: "MemoNotFound", code: 404, userInfo: nil))
+            }
+        } catch {
+            return .failure(error)
         }
     }
 }

--- a/COMFIE/Data/CoreData/CoreDataService.swift
+++ b/COMFIE/Data/CoreData/CoreDataService.swift
@@ -193,7 +193,7 @@ extension CoreDataService {
         }
     }
     
-    func deleteRetrospectionText(for memo: Memo) -> Result<Void, Error> {
+    func deleteRetrospection(for memo: Memo) -> Result<Void, Error> {
         let request = MemoEntity.fetchRequest()
         request.predicate = NSPredicate(format: "id == %@", memo.id as CVarArg)
         

--- a/COMFIE/Data/CoreData/Extensions/Memo+with.swift
+++ b/COMFIE/Data/CoreData/Extensions/Memo+with.swift
@@ -1,0 +1,18 @@
+//
+//  Memo+with.swift
+//  COMFIE
+//
+//  Created by Seoyeon Choi on 4/14/25.
+//
+
+extension Memo {
+    func with(retrospectionText: String?) -> Memo {
+        Memo(
+            id: self.id,
+            createdAt: self.createdAt,
+            originalText: self.originalText,
+            emojiText: self.emojiText,
+            retrospectionText: retrospectionText
+        )
+    }
+}

--- a/COMFIE/Data/Repository/RetrospectionRepository/RetrospectionRepository.swift
+++ b/COMFIE/Data/Repository/RetrospectionRepository/RetrospectionRepository.swift
@@ -5,7 +5,7 @@
 //  Created by Seoyeon Choi on 4/13/25.
 //
 
-final class RetrospectionRepository: RetrospectionRepsitoryProtocol {
+final class RetrospectionRepository: RetrospectionRepositoryProtocol {
     private let coreDataService: CoreDataService
     
     init(coreDataService: CoreDataService = CoreDataService()) {

--- a/COMFIE/Data/Repository/RetrospectionRepository/RetrospectionRepository.swift
+++ b/COMFIE/Data/Repository/RetrospectionRepository/RetrospectionRepository.swift
@@ -1,0 +1,22 @@
+//
+//  RetrospectionRepository.swift
+//  COMFIE
+//
+//  Created by Seoyeon Choi on 4/13/25.
+//
+
+final class RetrospectionRepository: RetrospectionRepsitoryProtocol {
+    private let coreDataService: CoreDataService
+    
+    init(coreDataService: CoreDataService = CoreDataService()) {
+        self.coreDataService = coreDataService
+    }
+    
+    func update(memo: Memo) -> Result<Void, any Error> {
+        coreDataService.updateRetrospectionText(for: memo, with: memo.retrospectionText ?? "")
+    }
+    
+    func delete(memo: Memo) -> Result<Void, any Error> {
+        coreDataService.deleteRetrospectionText(for: memo)
+    }
+}

--- a/COMFIE/Data/Repository/RetrospectionRepository/RetrospectionRepository.swift
+++ b/COMFIE/Data/Repository/RetrospectionRepository/RetrospectionRepository.swift
@@ -13,7 +13,7 @@ final class RetrospectionRepository: RetrospectionRepsitoryProtocol {
     }
     
     func update(memo: Memo) -> Result<Void, any Error> {
-        coreDataService.updateRetrospectionText(for: memo, with: memo.retrospectionText ?? "")
+        coreDataService.saveRetrospection(memo)
     }
     
     func delete(memo: Memo) -> Result<Void, any Error> {

--- a/COMFIE/Data/Repository/RetrospectionRepository/RetrospectionRepository.swift
+++ b/COMFIE/Data/Repository/RetrospectionRepository/RetrospectionRepository.swift
@@ -12,11 +12,11 @@ final class RetrospectionRepository: RetrospectionRepsitoryProtocol {
         self.coreDataService = coreDataService
     }
     
-    func update(memo: Memo) -> Result<Void, any Error> {
+    func save(memo: Memo) -> Result<Void, any Error> {
         coreDataService.saveRetrospection(memo)
     }
     
     func delete(memo: Memo) -> Result<Void, any Error> {
-        coreDataService.deleteRetrospectionText(for: memo)
+        coreDataService.deleteRetrospection(for: memo)
     }
 }

--- a/COMFIE/Data/Repository/RetrospectionRepository/RetrospectionRepositoryProtocol.swift
+++ b/COMFIE/Data/Repository/RetrospectionRepository/RetrospectionRepositoryProtocol.swift
@@ -1,11 +1,11 @@
 //
-//  RetrospectionRepsitoryProtocol.swift
+//  RetrospectionRepositoryProtocol.swift
 //  COMFIE
 //
 //  Created by Seoyeon Choi on 4/13/25.
 //
 
-protocol RetrospectionRepsitoryProtocol {
+protocol RetrospectionRepositoryProtocol {
     func save(memo: Memo) -> Result<Void, Error>
     func delete(memo: Memo) -> Result<Void, Error>
 }

--- a/COMFIE/Data/Repository/RetrospectionRepository/RetrospectionRepsitoryProtocol.swift
+++ b/COMFIE/Data/Repository/RetrospectionRepository/RetrospectionRepsitoryProtocol.swift
@@ -6,6 +6,6 @@
 //
 
 protocol RetrospectionRepsitoryProtocol {
-    func update(memo: Memo) -> Result<Void, Error>
+    func save(memo: Memo) -> Result<Void, Error>
     func delete(memo: Memo) -> Result<Void, Error>
 }

--- a/COMFIE/Data/Repository/RetrospectionRepository/RetrospectionRepsitoryProtocol.swift
+++ b/COMFIE/Data/Repository/RetrospectionRepository/RetrospectionRepsitoryProtocol.swift
@@ -1,0 +1,11 @@
+//
+//  RetrospectionRepsitoryProtocol.swift
+//  COMFIE
+//
+//  Created by Seoyeon Choi on 4/13/25.
+//
+
+protocol RetrospectionRepsitoryProtocol {
+    func update(memo: Memo) -> Result<Void, Error>
+    func delete(memo: Memo) -> Result<Void, Error>
+}

--- a/COMFIE/Presentation/ComfieZoneSetting/BottomSheet/ComfieZoneSettingBottomSheet.swift
+++ b/COMFIE/Presentation/ComfieZoneSetting/BottomSheet/ComfieZoneSettingBottomSheet.swift
@@ -62,6 +62,6 @@ struct ComfieZoneSettingBottomSheet: View {
 
 #Preview {
     ComfieZoneSettingView(
-        intent: ComfieZoneSettingStore()
+        intent: ComfieZoneSettingStore(popupIntent: .init())
     )
 }

--- a/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingView.swift
+++ b/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingView.swift
@@ -75,6 +75,6 @@ struct ComfieZoneSettingView: View {
 
 #Preview {
     ComfieZoneSettingView(
-        intent: ComfieZoneSettingStore()
+        intent: ComfieZoneSettingStore(popupIntent: .init())
     )
 }

--- a/COMFIE/Presentation/Memo/MemoStore.swift
+++ b/COMFIE/Presentation/Memo/MemoStore.swift
@@ -243,7 +243,8 @@ extension MemoStore {
         switch action {
         case .toRetrospection(let memo):
             // TODO: 이후에 회고 뷰에 메모를 전달해줘야 한다.
-            router.push(.retrospection)
+            router.push(.retrospection(memo: memo))
+            return state
         case .toComfieZoneSetting:
             router.push(.comfieZoneSetting)
         case .toMore:

--- a/COMFIE/Presentation/Memo/MemoStore.swift
+++ b/COMFIE/Presentation/Memo/MemoStore.swift
@@ -242,7 +242,6 @@ extension MemoStore {
     private func handleNavigationAction(_ state: State, _ action: Action.NavigationAction) -> State {
         switch action {
         case .toRetrospection(let memo):
-            // TODO: 이후에 회고 뷰에 메모를 전달해줘야 한다.
             router.push(.retrospection(memo: memo))
             return state
         case .toComfieZoneSetting:

--- a/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
+++ b/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
@@ -100,6 +100,7 @@ class RetrospectionStore: IntentStore {
         case .completeButtonTapped:
             performSideEffect(for: .ui(.removeContentFieldFocus))
             state = handleAction(state, .hideCompleteButton)
+            state = handleAction(state, .saveRetrospection)
             
         case .deleteRetrospectionButtonTapped:
             state = handleAction(state, .deleteRetrospection)

--- a/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
+++ b/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
@@ -15,14 +15,14 @@ class RetrospectionStore: IntentStore {
     let sideEffectPublisher = PassthroughSubject<SideEffect, Never>()
     
     private let router: Router
-    private let repository: RetrospectionRepsitoryProtocol
+    private let repository: RetrospectionRepositoryProtocol
     
     let memo: Memo
     
     private var cancellables = Set<AnyCancellable>()
     private let inputContentSubject = CurrentValueSubject<String, Never>("")
     
-    init(router: Router, repository: RetrospectionRepsitoryProtocol, memo: Memo) {
+    init(router: Router, repository: RetrospectionRepositoryProtocol, memo: Memo) {
         self.router = router
         self.repository = repository
         self.memo = memo

--- a/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
+++ b/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
@@ -27,7 +27,7 @@ class RetrospectionStore: IntentStore {
     
     struct State {
         var originalMemo: String = ""
-        var inputContent: String = ""
+        var inputContent: String?
         var showCompleteButton: Bool = false
         var showDeletePopupView: Bool = false
     }
@@ -130,32 +130,34 @@ class RetrospectionStore: IntentStore {
     }
 }
 
-//MARK: - Helper Methods
+// MARK: - Helper Methods
+
 extension RetrospectionStore {
     private func saveRetrospection(_ state: State) -> State {
         var newState = state
+        if newState.inputContent == "" { newState.inputContent = nil }
         let memo = Memo(id: memo.id,
                         createdAt: memo.createdAt,
                         originalText: memo.originalText,
                         emojiText: memo.emojiText,
                         retrospectionText: newState.inputContent)
-        switch repository.update(memo: memo) {
-        case .success(let success):
-            print("저장 성공!")
-        case .failure(let failure):
-            print("\(memo)저장을 실패했습니다.")
+        switch repository.save(memo: memo) {
+        case .success:
+            print("회고 저장 성공")
+        case .failure(let error):
+            print("회고 저장 실패: \(error)")
         }
         
         return newState
     }
     
     private func deleteRetrospection(_ state: State) -> State {
-        var newState = state
+        let newState = state
         switch repository.delete(memo: memo) {
-        case .success(let success):
-            print("삭제 성공!")
-        case .failure(let failure):
-            print("\(memo)삭제를 실패했습니다.")
+        case .success:
+            print("회고 삭제 성공")
+        case .failure(let error):
+            print("회고 삭제 실패: \(error)")
         }
         
         return newState

--- a/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
+++ b/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
@@ -90,7 +90,8 @@ class RetrospectionStore: IntentStore {
         case .contentFieldTapped:
             performSideEffect(for: .ui(.setContentFieldFocus))
             state = handleAction(state, .showCompleteButton)
-        case .updateRetrospection(let content): state = handleAction(state, .updateRetrospection(content))
+        case .updateRetrospection(let content):
+            state = handleAction(state, .updateRetrospection(content))
             
         case .backButtonTapped: state = handleAction(state, .saveRetrospection)
         case .deleteMenuButtonTapped:
@@ -119,8 +120,8 @@ class RetrospectionStore: IntentStore {
         case .showCompleteButton: newState.showCompleteButton = true
         case .hideCompleteButton: newState.showCompleteButton = false
             
-        case .saveRetrospection: _ = saveRetrospection(newState)
-        case .deleteRetrospection: _ = deleteRetrospection(newState)
+        case .saveRetrospection: saveRetrospection(newState)
+        case .deleteRetrospection: deleteRetrospection(newState)
             
         case .showDeletePopupView: newState.showDeletePopupView = true
         case .hideDeletePopupView: newState.showDeletePopupView = false

--- a/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
+++ b/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
@@ -16,8 +16,13 @@ class RetrospectionStore: IntentStore {
     
     private let router: Router
     
-    init(router: Router) {
+    let memo: Memo
+    
+    init(router: Router, memo: Memo) {
         self.router = router
+        self.memo = memo
+        
+        self.state.originalMemo = memo.originalText
     }
     
     struct State {

--- a/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
+++ b/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
@@ -26,8 +26,11 @@ class RetrospectionStore: IntentStore {
     }
     
     struct State {
+        // 메모 관련 데이터
         var originalMemo: String = ""
         var inputContent: String?
+        var createdDate: String = ""
+        
         var showCompleteButton: Bool = false
         var showDeletePopupView: Bool = false
     }
@@ -114,9 +117,8 @@ class RetrospectionStore: IntentStore {
         switch action {
         case .fetchMemo:
             newState.originalMemo = memo.originalText
-            if let retrospection = memo.retrospectionText {
-                newState.inputContent = retrospection
-            }
+            if let retrospection = memo.retrospectionText { newState.inputContent = retrospection }
+            newState.createdDate = memo.createdAt.toFormattedDateTimeString()
         case .updateRetrospection(let text): newState.inputContent = text
         case .showCompleteButton: newState.showCompleteButton = true
         case .hideCompleteButton: newState.showCompleteButton = false

--- a/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
+++ b/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
@@ -133,34 +133,25 @@ class RetrospectionStore: IntentStore {
 // MARK: - Helper Methods
 
 extension RetrospectionStore {
-    private func saveRetrospection(_ state: State) -> State {
-        var newState = state
-        if newState.inputContent == "" { newState.inputContent = nil }
-        let memo = Memo(id: memo.id,
-                        createdAt: memo.createdAt,
-                        originalText: memo.originalText,
-                        emojiText: memo.emojiText,
-                        retrospectionText: newState.inputContent)
-        switch repository.save(memo: memo) {
+    private func saveRetrospection(_ state: State) {
+        let content = state.inputContent?.isEmpty == true ? nil : state.inputContent
+        let updatedmemo = memo.with(retrospectionText: content)
+        
+        switch repository.save(memo: updatedmemo) {
         case .success:
             print("회고 저장 성공")
         case .failure(let error):
             print("회고 저장 실패: \(error)")
         }
-        
-        return newState
     }
     
-    private func deleteRetrospection(_ state: State) -> State {
-        let newState = state
+    private func deleteRetrospection(_ state: State) {
         switch repository.delete(memo: memo) {
         case .success:
             print("회고 삭제 성공")
         case .failure(let error):
             print("회고 삭제 실패: \(error)")
         }
-        
-        return newState
     }
 }
 

--- a/COMFIE/Presentation/Retrospection/RetrospectionView.swift
+++ b/COMFIE/Presentation/Retrospection/RetrospectionView.swift
@@ -54,7 +54,7 @@ struct RetrospectionView: View {
                         VStack(spacing: 0) {
                             TextField(stringLiterals.contentPlaceholder.localized,
                                       text: Binding(
-                                        get: { intent.state.inputContent },
+                                        get: { intent.state.inputContent ?? "" },
                                         set: { intent(.updateRetrospection($0)) }
                                       ),
                                       axis: .vertical)

--- a/COMFIE/Presentation/Retrospection/RetrospectionView.swift
+++ b/COMFIE/Presentation/Retrospection/RetrospectionView.swift
@@ -147,5 +147,6 @@ struct RetrospectionView: View {
 
 #Preview {
     RetrospectionView(intent: .init(router: .init(),
+                                    repository: RetrospectionRepository(coreDataService: .init()),
                                     memo: Memo(id: .init(), createdAt: .distantFuture, originalText: "", emojiText: "")))
 }

--- a/COMFIE/Presentation/Retrospection/RetrospectionView.swift
+++ b/COMFIE/Presentation/Retrospection/RetrospectionView.swift
@@ -146,5 +146,6 @@ struct RetrospectionView: View {
 }
 
 #Preview {
-    RetrospectionView(intent: .init(router: .init()))
+    RetrospectionView(intent: .init(router: .init(),
+                                    memo: Memo(id: .init(), createdAt: .distantFuture, originalText: "", emojiText: "")))
 }

--- a/COMFIE/Presentation/Retrospection/RetrospectionView.swift
+++ b/COMFIE/Presentation/Retrospection/RetrospectionView.swift
@@ -28,8 +28,7 @@ struct RetrospectionView: View {
                     ScrollView {
                         VStack(spacing: 0) {
                             HStack(spacing: 0) {
-                                // memo.createdDate 연결 필요
-                                Text(Date().toFormattedDateTimeString())
+                                Text(intent.state.createdDate)
                                     .comfieFont(.systemBody)
                                     .foregroundStyle(.cfBlack.opacity(0.6))
                                 


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### 🔖 Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- close #21 

<br>

### 📚 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->
- 회고뷰에 필요한 기능을 구현했습니다. 
    - CoreData를 사용한 CRUD 구현

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->

https://github.com/user-attachments/assets/a786d87c-e34b-488a-be61-7cb9d7cc1b6d


<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->
- `MemoView` 내 아래 코드를 **true** 로 바꿔서 테스트 해보시면 됩니다 !
```swift
// 컴피존 관련 모델에서 주입 받아야 한다.
@State private var isUserInComfieZone: Bool = true
```

- 호랑이 구현해둔 Memo 관련 CoreData코드 참고하여 컨벤션 맞춰 작업 진행했습니다!
<br>
