### PR TITLE
✨ Feat: #31 메모 스크롤 뷰 포커싱 기능 추가

### DIFF
--- a/COMFIE/Presentation/Memo/MemoInput/MemoInputUITextView.swift
+++ b/COMFIE/Presentation/Memo/MemoInput/MemoInputUITextView.swift
@@ -139,16 +139,16 @@ struct MemoInputUITextView: UIViewRepresentable {
         
         /// MemoStore에서 전달된 sideEffect를 감지하여 포커스를 제어하거나, 상태 기반으로 입력 뷰를 갱신합니다.
         func bindFocusControl() {
-            intent.sideEffectPublisher
+            intent.uiSideEffectPublisher
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] sideEffect in
                     guard let self = self else { return }
                     switch sideEffect {
-                    case .ui(.resignInputFocusWithSyncInput):
+                    case .resignInputFocusWithSyncInput:
                         self.unfocusTextView(textView)
-                    case .ui(.setMemoInputFocus):
+                    case .setMemoInputFocus:
                         self.focusTextView(textView)
-                    case .ui(.updateInputViewWithState):
+                    case .updateInputViewWithState:
                         self.textView.text = intent.state.inputMemoText
                         
                         updatePlaceholderVisibility(textView)

--- a/COMFIE/Presentation/Memo/MemoListView.swift
+++ b/COMFIE/Presentation/Memo/MemoListView.swift
@@ -52,7 +52,7 @@ struct MemoListView: View {
                 }
                 .scrollIndicators(.hidden)
                 .defaultScrollAnchor(.bottom)
-                .onReceive(intent.scrollEffectPublisher) { effect in
+                .onReceive(intent.scrollSideEffectPublisher) { effect in
                     switch effect {
                     case .toMemo(let id):
                         Task { @MainActor in

--- a/COMFIE/Presentation/Memo/MemoListView.swift
+++ b/COMFIE/Presentation/Memo/MemoListView.swift
@@ -48,6 +48,7 @@ struct MemoListView: View {
                     .padding(24)
                 }
                 .scrollIndicators(.hidden)
+                .defaultScrollAnchor(.bottom)
                 .onChange(of: intent.state.editingMemo) {
                     guard let editingMemo = intent.state.editingMemo else { return }
                     

--- a/COMFIE/Presentation/Memo/MemoListView.swift
+++ b/COMFIE/Presentation/Memo/MemoListView.swift
@@ -25,27 +25,39 @@ struct MemoListView: View {
                     .foregroundStyle(.textDarkgray)
             }
         } else {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 24) {
-                    ForEach(intent.state.groupedMemos, id: \.date) { group in
-                        VStack(alignment: .leading, spacing: 12) {
-                            Text(group.date)
-                                .comfieFont(.systemBody)
-                                .foregroundStyle(.textDarkgray)
-                            
-                            ForEach(group.memos) { memo in
-                                MemoCell(
-                                    memo: memo,
-                                    intent: $intent,
-                                    isUserInComfieZone: isUserInComfieZone
-                                )
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 24) {
+                        ForEach(intent.state.groupedMemos, id: \.date) { group in
+                            VStack(alignment: .leading, spacing: 12) {
+                                Text(group.date)
+                                    .comfieFont(.systemBody)
+                                    .foregroundStyle(.textDarkgray)
+                                
+                                ForEach(group.memos) { memo in
+                                    MemoCell(
+                                        memo: memo,
+                                        intent: $intent,
+                                        isUserInComfieZone: isUserInComfieZone
+                                    )
+                                    .id(memo.id)
+                                }
                             }
                         }
                     }
+                    .padding(24)
                 }
-                .padding(24)
+                .scrollIndicators(.hidden)
+                .onChange(of: intent.state.editingMemo) {
+                    guard let editingMemo = intent.state.editingMemo else { return }
+                    
+                    Task { @MainActor in
+                        withAnimation {
+                            proxy.scrollTo(editingMemo.id, anchor: UnitPoint(x: 0.5, y: 0.8))
+                        }
+                    }
+                }
             }
-            .scrollIndicators(.hidden)
         }
     }
 }

--- a/COMFIE/Presentation/Memo/MemoListView.swift
+++ b/COMFIE/Presentation/Memo/MemoListView.swift
@@ -14,6 +14,8 @@ struct MemoListView: View {
     // TODO: isUserInComfieZone 변경 필요
     @Binding var isUserInComfieZone: Bool
     
+    @Namespace private var scrollViewBottomId
+    
     var body: some View {
         if intent.state.memos.isEmpty {
             ZStack(alignment: .center) {
@@ -46,15 +48,23 @@ struct MemoListView: View {
                         }
                     }
                     .padding(24)
+                    .id(scrollViewBottomId)
                 }
                 .scrollIndicators(.hidden)
                 .defaultScrollAnchor(.bottom)
-                .onChange(of: intent.state.editingMemo) {
-                    guard let editingMemo = intent.state.editingMemo else { return }
-                    
-                    Task { @MainActor in
-                        withAnimation {
-                            proxy.scrollTo(editingMemo.id, anchor: UnitPoint(x: 0.5, y: 0.8))
+                .onReceive(intent.scrollEffectPublisher) { effect in
+                    switch effect {
+                    case .toMemo(let id):
+                        Task { @MainActor in
+                            withAnimation {
+                                proxy.scrollTo(id, anchor: UnitPoint(x: 0.5, y: 0.8))
+                            }
+                        }
+                    case .toBottom:
+                        Task { @MainActor in
+                            withAnimation {
+                                proxy.scrollTo(scrollViewBottomId, anchor: .bottom)
+                            }
                         }
                     }
                 }

--- a/COMFIE/Presentation/Memo/MemoStore.swift
+++ b/COMFIE/Presentation/Memo/MemoStore.swift
@@ -127,25 +127,25 @@ class MemoStore: IntentStore {
     // MARK: Side Effect
     enum SideEffect {
         case ui(UI)
+        case scroll(Scroll)
         
         enum UI {
             case resignInputFocusWithSyncInput
             case setMemoInputFocus
             case updateInputViewWithState
         }
-    }
-    
-    // MARK: ScrollEffect
-    enum ScrollEffect {
-        case toMemo(id: UUID)
-        case toBottom
+        
+        enum Scroll {
+            case toMemo(id: UUID)
+            case toBottom
+        }
     }
     
     private let router: Router
     private let memoRepository: MemoRepositoryProtocol
     
-    private(set) var sideEffectPublisher = PassthroughSubject<SideEffect, Never>()
-    private(set) var scrollEffectPublisher = PassthroughSubject<ScrollEffect, Never>()
+    private(set) var uiSideEffectPublisher = PassthroughSubject<SideEffect.UI, Never>()
+    private(set) var scrollSideEffectPublisher = PassthroughSubject<SideEffect.Scroll, Never>()
     
     // MARK: Init
     init(router: Router, memoRepository: MemoRepositoryProtocol) {
@@ -166,7 +166,7 @@ class MemoStore: IntentStore {
         case .onAppear:
             state = handleAction(state, .memo(.fetchAll))
         case .backgroundTapped:
-            performSideEffect(for: .ui(.resignInputFocusWithSyncInput))
+            performUISideEffect(for: .resignInputFocusWithSyncInput)
         case .comfieZoneSettingButtonTapped:
             state = handleAction(state, .navigation(.toComfieZoneSetting))
         case .moreButtonTapped:
@@ -196,16 +196,16 @@ extension MemoStore {
             return handleAction(state, .popup(.showDeletePopup(memo)))
         case .editButtonTapped(let memo):
             let newState = handleAction(state, .input(.startEditing(memo)))
-            performSideEffect(for: .ui(.updateInputViewWithState))
-            performSideEffect(for: .ui(.setMemoInputFocus))
+            performUISideEffect(for: .updateInputViewWithState)
+            performUISideEffect(for: .setMemoInputFocus)
             
             // 메모 수정 시, 해당 메모 위치로 스크롤 이동
-            performSCrollEffect(for: .toMemo(id: memo.id))
+            performScrollEffect(for: .toMemo(id: memo.id))
             return newState
         case .editingCancelButtonTapped:
             let newState = handleAction(state, .input(.cancelEditing))
-            performSideEffect(for: .ui(.updateInputViewWithState))
-            performSideEffect(for: .ui(.resignInputFocusWithSyncInput))
+            performUISideEffect(for: .updateInputViewWithState)
+            performUISideEffect(for: .resignInputFocusWithSyncInput)
             return newState
         case .retrospectionButtonTapped(let memo):
             let newState = handleNavigationAction(state, .toRetrospection(memo))
@@ -217,7 +217,7 @@ extension MemoStore {
         switch intent {
         case .memoInputButtonTapped:
             // ⚠️ 텍스트뷰에 보이는 값과 상태가 불일치하는 문제 방지를 위해, 입력 종료 시 델리게이트 메서드에서 동기화 메서드를 추가로 실행함.
-            performSideEffect(for: .ui(.resignInputFocusWithSyncInput))
+            performUISideEffect(for: .resignInputFocusWithSyncInput)
             
             // resignFirstResponder 호출과 그 후 동작들이 모두 메인 스레드(MainActor)에서 실행되어 순서가 보장됨.
             Task { @MainActor in
@@ -229,11 +229,11 @@ extension MemoStore {
                     self.state = handleAction(state, .memo(.save))
                     
                     // 메모가 추가 시, 해당 메모 위치(bottom)으로 스크롤 이동
-                    performSCrollEffect(for: .toBottom)
+                    performScrollEffect(for: .toBottom)
                 }
             }
             
-            performSideEffect(for: .ui(.updateInputViewWithState))
+            performUISideEffect(for: .updateInputViewWithState)
             // 🥲 여기 리턴 값은 사실상 의미 없는 값
             return state
         case .updateNewMemo(let text):
@@ -332,12 +332,12 @@ extension MemoStore {
 
 // MARK: - Side Effect Method
 extension MemoStore {
-    private func performSideEffect(for action: SideEffect) {
-        sideEffectPublisher.send(action)
+    private func performUISideEffect(for action: SideEffect.UI) {
+        uiSideEffectPublisher.send(action)
     }
     
-    private func performSCrollEffect(for action: ScrollEffect) {
-        scrollEffectPublisher.send(action)
+    private func performScrollEffect(for action: SideEffect.Scroll) {
+        scrollSideEffectPublisher.send(action)
     }
 }
 


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### 🔖 Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- close #31 

<br>

### 📚 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

메모 뷰에서 특정 메모가 우선적으로 보이도록 포커싱 기능을 추가했습니다.
- 화면 진입 시, 가장 최근 메모(화면 하단)가 자동으로 보이도록 기본 앵커를 하단으로 고정했습니다.
- 메모가 수정될 경우, 해당 메모가 스크롤 뷰 중앙에 오도록 포커싱됩니다.
- 메모가 새로 추가될 경우, 해당 메모가 위치한 스크롤 뷰 하단으로 이동하여 포커싱됩니다.
<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->


<br>
