### PR TITLE
🐛 Fix: CPU 점유율 203-205% -> 1-2% 감소

### DIFF
--- a/COMFIE/App/COMFIEApp.swift
+++ b/COMFIE/App/COMFIEApp.swift
@@ -9,9 +9,19 @@ import SwiftUI
 
 @main
 struct COMFIEApp: App {
+    @State private var router: Router
+    private var diContainer: DIContainer
+    
+    init() {
+        let router = Router()
+        self.router = router
+        self.diContainer = DIContainer(router: router)
+    }
+    
     var body: some Scene {
         WindowGroup {
-            COMFIERoutingView()
+            COMFIERoutingView(diContainer: diContainer)
+                .environment(router)
         }
     }
 }

--- a/COMFIE/App/COMFIERoutingView.swift
+++ b/COMFIE/App/COMFIERoutingView.swift
@@ -8,14 +8,16 @@
 import SwiftUI
 
 struct COMFIERoutingView: View {
-    @State private var router: Router = Router()
+    @Environment(Router.self) private var router
+    let diContainer: DIContainer
     
     var body: some View {
+        @Bindable var router = router
         NavigationStack(path: $router.path) {
-            router.rootView()
+            router.rootView(diContainer)
                 .onAppear { finishLoadingView() }
                 .navigationDestination(for: Route.self) { route in
-                    route.view(router)
+                    route.view(diContainer)
                 }
         }
         .environment(router)
@@ -29,8 +31,4 @@ struct COMFIERoutingView: View {
             }
         }
     }
-}
-
-#Preview {
-    COMFIERoutingView()
 }

--- a/COMFIE/App/DIContainer/DIContainer.swift
+++ b/COMFIE/App/DIContainer/DIContainer.swift
@@ -7,8 +7,12 @@
 
 import SwiftUI
 
-struct DIContainer {
+class DIContainer {
     let router: Router
+    
+    init(router: Router) {
+        self.router = router
+    }
     
     // MARK: - Repository
     let memoRepository: MemoRepositoryProtocol = MemoRepository()
@@ -16,12 +20,12 @@ struct DIContainer {
     let comfieZoneRepository: ComfieZoneRepositoryProtocol = ComfieZoneRepository()
     
     // MARK: - Service
-    private func makeLocationService() -> LocationService { LocationService() }
+    lazy var makeLocationService: LocationService = { LocationService() }()
     
     // MARK: - UseCase
     private func makeLocationUseCase() -> LocationUseCase {
         LocationUseCase(
-            locationService: makeLocationService(),
+            locationService: makeLocationService,
             comfiZoneRepository: comfieZoneRepository
         )
     }

--- a/COMFIE/App/Router/Route.swift
+++ b/COMFIE/App/Router/Route.swift
@@ -22,7 +22,7 @@ enum Route: Hashable {
     case privacyPolicy
     case makers
     
-    @ViewBuilder func view(_ router: Router) -> some View {
-        DIContainer(router: router).makeView(self)
+    @ViewBuilder func view(_ diContainer: DIContainer) -> some View {
+        diContainer.makeView(self)
     }
 }

--- a/COMFIE/App/Router/Router.swift
+++ b/COMFIE/App/Router/Router.swift
@@ -37,13 +37,13 @@ class Router {
     }
     
     // 가장 상위 View - 앱 진입 시 파악
-    @ViewBuilder func rootView() -> some View {
+    @ViewBuilder func rootView(_ diContainer: DIContainer) -> some View {
         if isLoadingViewFinished == false {
-            Route.loading.view(self)     // 앱 진입 시, 로딩 View
+            Route.loading.view(diContainer)     // 앱 진입 시, 로딩 View
         } else if hasEverOnboarded == false {
-            Route.onboarding.view(self)  // 앱 최초 실행 O -> 온보딩 View
+            Route.onboarding.view(diContainer)  // 앱 최초 실행 O -> 온보딩 View
         } else {
-            Route.memo.view(self)        // 앱 최초 실행 X -> 메모 View
+            Route.memo.view(diContainer)        // 앱 최초 실행 X -> 메모 View
         }
     }
 }


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### 📚 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

이전 작업 이후, 화면 진입 시 기기 발열과 CPU 200% 이상의 문제가 발생했습니다.
처음에는 Location 변경에 따른 지속적인 Publish가 문제인 줄 알았으나,
모든 코드를 주석처리한 이후에도 계속해서 같은 현상이 나타났습니다.

Instrument에서 가장 많이 실행되는 곳이 RoutingView와 DIContainer였고,
처음에는 이 내부에 무언가 다른 반복 실행되는 곳이 있다고 여겼습니다.

그런데 실제로 Route에서 기존에 새로운 View를 만들 때마다 DIContainer 전체를 재생성하고 있었습니다.
이에 따라 모든 Repository, Service, ... 등이 모두 재생성되는 이슈가 있었습니다.

그래서 처음에는 Router와 DIContainer를 상단에서 처음 생성하여 앱 전역에 주입하고,
Router에서 View를 생성하던 방식을 DIContainer가 생성하도록 변경했습니다.
(전체적인 코드 리팩토링을 하려 했으나, 너무 큰 작업이 될 것 같아서 우선 눈에 보이는 코드들부터 변경했습니다.)
반영 이후 200%가 넘는 CPU 점유율에서 140% 정도로 낮아진 모습을 볼 수 있었습니다.

그러나 여전히 CPU가 너무 많이 쓰이고 있었고, 더 이유를 찾아보게 되었습니다.
확인 결과 LocationService가 너무 많이 재생성되고 있었습니다.
그래서 LocationService를 한 번 생성 후에 활용할 수 있도록 lazy var 처리를 해주었습니다.
그리고 DIContainer 또한 struct에서 class로 변경하여 한 번만 생성하여 활용할 수 있도록 변경했습니다.
반영 이후 140% 내외에서 0-3% 정도로 완전히 낮아진 모습을 보였습니다.

저도 해결은 했으나, 더 정확한(?) 명확한(?) 원인을 설명하기에 아직 이해되지 않은 부분이 있습니다!
계속해서 재생성하도록 많드는 근본적인 원인 파악을 하지 못한 상태입니다.
(위치 변경이라고 생각했으나, 관련 코드를 모두 지운 상태에도 같은 모습을 보였습니다.)
(추가로 MemoInputView와 관련된 동작도 반복적으로 실행되는 모습을 목격했었습니다.. -> 원인 모름(?))

이렇게 모두 반영한 이후, 오늘 제기되었던 '나의 위치' 화면에서 도움말 팝업이 뜨지 않는 이슈도 해결되었습니다.

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->
(가지고 있는 사진이 이것뿐이네요..)
<img width="252" height="128" alt="image" src="https://github.com/user-attachments/assets/47667f46-b8d6-4d22-9905-f8d473090f97" />

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->

추가로 기존에 작업하려던 위치 관련 작업을 마무리하지 못했습니다..
이어서 바로 하려고 했는데.. 최대한 빠르게 마무리하겠습니다!

<br>
