### PR TITLE
Fix: 회고 관련 QA 사항 이슈 수정

### DIFF
--- a/COMFIE/Data/CoreData/CoreDataService.swift
+++ b/COMFIE/Data/CoreData/CoreDataService.swift
@@ -72,7 +72,8 @@ extension CoreDataService {
         
         do {
             if let entity = try context.fetch(request).first {
-                entity.retrospectionText = memo.retrospectionText
+                entity.originalRetrospectionText = memo.originalRetrospectionText
+                entity.emojiRetrospectionText = memo.emojiRetrospectionText
                 try context.save()
                 return .success(())
             } else {
@@ -130,7 +131,8 @@ extension CoreDataService {
             // 기존 데이터 업데이트
             entity.originalText = newMemo.originalText
             entity.emojiText = newMemo.emojiText
-            entity.retrospectionText = newMemo.retrospectionText
+            entity.originalRetrospectionText = newMemo.originalRetrospectionText
+            entity.emojiRetrospectionText = newMemo.emojiRetrospectionText
             
             try self.context.save()
             return .success(())
@@ -200,7 +202,8 @@ extension CoreDataService {
         
         do {
             if let entity = try context.fetch(request).first {
-                entity.retrospectionText = nil
+                entity.originalRetrospectionText = nil
+                entity.emojiRetrospectionText = nil
                 try context.save()
                 return .success(())
             } else {

--- a/COMFIE/Data/CoreData/CoreDataTestView.swift
+++ b/COMFIE/Data/CoreData/CoreDataTestView.swift
@@ -111,7 +111,7 @@ struct CoreDataTestView: View {
     private func addMemo() {
         guard !newMemoText.isEmpty else { return }
         
-        let newMemo = Memo(id: UUID(), createdAt: .now, originalText: newMemoText, emojiText: "😊", retrospectionText: "회고")
+        let newMemo = Memo(id: UUID(), createdAt: .now, originalText: newMemoText, emojiText: "😊", originalRetrospectionText: "회고", emojiRetrospectionText: "🤩")
         let result = coreDataService.saveMemo(newMemo)
         
         switch result {

--- a/COMFIE/Data/CoreData/Extensions/Memo+fromEntity.swift
+++ b/COMFIE/Data/CoreData/Extensions/Memo+fromEntity.swift
@@ -23,7 +23,8 @@ extension Memo {
             createdAt: createdAt,
             originalText: originalText,
             emojiText: emojiText,
-            retrospectionText: entity.retrospectionText
+            originalRetrospectionText: entity.originalRetrospectionText,
+            emojiRetrospectionText: entity.emojiRetrospectionText
         )
         
         return .success(memo)

--- a/COMFIE/Data/CoreData/Extensions/Memo+toEntity.swift
+++ b/COMFIE/Data/CoreData/Extensions/Memo+toEntity.swift
@@ -14,8 +14,8 @@ extension Memo {
         entity.createdAt = memo.createdAt
         entity.originalText = memo.originalText
         entity.emojiText = memo.emojiText
-        entity.retrospectionText = memo.retrospectionText
-        
+        entity.originalRetrospectionText = memo.originalRetrospectionText
+        entity.emojiRetrospectionText = memo.emojiRetrospectionText
         return entity
     }
 }

--- a/COMFIE/Data/CoreData/Extensions/Memo+with.swift
+++ b/COMFIE/Data/CoreData/Extensions/Memo+with.swift
@@ -6,13 +6,14 @@
 //
 
 extension Memo {
-    func with(retrospectionText: String?) -> Memo {
+    func with(originalRetrospectionText: String?, emojiRetrospectionText: String?) -> Memo {
         Memo(
             id: self.id,
             createdAt: self.createdAt,
             originalText: self.originalText,
             emojiText: self.emojiText,
-            retrospectionText: retrospectionText
+            originalRetrospectionText: originalRetrospectionText,
+            emojiRetrospectionText: emojiRetrospectionText
         )
     }
 }

--- a/COMFIE/Data/CoreData/UserRecordModel.xcdatamodeld/UserRecordModel.xcdatamodel/contents
+++ b/COMFIE/Data/CoreData/UserRecordModel.xcdatamodeld/UserRecordModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24D70" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="ComfieZoneEntity" representedClassName="ComfieZoneEntity" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="latitude" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
@@ -8,9 +8,10 @@
     </entity>
     <entity name="MemoEntity" representedClassName="MemoEntity" syncable="YES" codeGenerationType="class">
         <attribute name="createdAt" attributeType="Date" defaultDateTimeInterval="763480860" usesScalarValueType="NO"/>
+        <attribute name="emojiRetrospectionText" optional="YES" attributeType="String"/>
         <attribute name="emojiText" attributeType="String" defaultValueString=""/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="originalRetrospectionText" optional="YES" attributeType="String"/>
         <attribute name="originalText" attributeType="String" defaultValueString=""/>
-        <attribute name="retrospectionText" optional="YES" attributeType="String"/>
     </entity>
 </model>

--- a/COMFIE/Domain/Entity/Memo.swift
+++ b/COMFIE/Domain/Entity/Memo.swift
@@ -12,14 +12,15 @@ struct Memo: Identifiable, Hashable {
     let createdAt: Date
     var originalText: String
     var emojiText: String
-    var retrospectionText: String?
+    var originalRetrospectionText: String?
+    var emojiRetrospectionText: String?
 }
 
 /// dummy memo
 extension Memo {
     static var sampleMemos: [Memo] {
-        [Memo(id: UUID(), createdAt: Date(), originalText: "첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모", emojiText: "😀", retrospectionText: "첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모"),
-        Memo(id: UUID(), createdAt: Date(), originalText: "두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모", emojiText: "📚", retrospectionText: "두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모"),
+        [Memo(id: UUID(), createdAt: Date(), originalText: "첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모", emojiText: "😀", originalRetrospectionText: "첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모첫 번째 메모", emojiRetrospectionText: "🤩"),
+        Memo(id: UUID(), createdAt: Date(), originalText: "두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모", emojiText: "📚", originalRetrospectionText: "두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모두 번째 메모", emojiRetrospectionText: "🤩"),
         Memo(id: UUID(), createdAt: Date().addingTimeInterval(-86400), originalText: "세 번째 메모", emojiText: "✈️"),
         Memo(id: UUID(), createdAt: Date().addingTimeInterval(-86400 * 2), originalText: "네 번째 메모", emojiText: "🍔"),
         Memo(id: UUID(), createdAt: Date().addingTimeInterval(-86400 * 2), originalText: "다섯 번째 메모", emojiText: "🏀")

--- a/COMFIE/Presentation/Memo/MemoCell.swift
+++ b/COMFIE/Presentation/Memo/MemoCell.swift
@@ -24,7 +24,7 @@ struct MemoCell: View {
     }
     
     private var hasRetrospection: Bool {
-        memo.retrospectionText != nil
+        memo.originalRetrospectionText != nil
     }
     
     private var shouldShowMemo: Bool {
@@ -72,9 +72,10 @@ struct MemoCell: View {
             }
             
             // 회고가 있는 경우
-            if let retrospectionText = memo.retrospectionText {
+            if let originalRetrospectionText = memo.originalRetrospectionText,
+               let emojiRetrospectionText = memo.emojiRetrospectionText {
                 HStack {
-                    Text(isUserInComfieZone ? retrospectionText : memo.emojiText)
+                    Text(isUserInComfieZone ? originalRetrospectionText : emojiRetrospectionText)
                         .lineLimit(3)
                     Spacer()
                 }

--- a/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
+++ b/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
@@ -122,7 +122,7 @@ class RetrospectionStore: IntentStore {
         switch action {
         case .fetchMemo:
             newState.originalMemo = memo.originalText
-            if let retrospection = memo.retrospectionText { newState.inputContent = retrospection }
+            if let retrospection = memo.originalRetrospectionText { newState.inputContent = retrospection }
             newState.createdDate = memo.createdAt.toFormattedDateTimeString()
         case .updateRetrospection(let text): newState.inputContent = text
         case .showCompleteButton: newState.showCompleteButton = true
@@ -144,7 +144,7 @@ class RetrospectionStore: IntentStore {
 extension RetrospectionStore {
     private func saveRetrospection(_ state: State) {
         let content = state.inputContent?.isEmpty == true ? nil : state.inputContent
-        let updatedmemo = memo.with(retrospectionText: content)
+        let updatedmemo = memo.with(originalRetrospectionText: content, emojiRetrospectionText: "🍀🎉🥰")
         
         switch repository.save(memo: updatedmemo) {
         case .success:

--- a/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
+++ b/COMFIE/Presentation/Retrospection/RetrospectionStore.swift
@@ -36,6 +36,8 @@ class RetrospectionStore: IntentStore {
         var inputContent: String?
         var createdDate: String = ""
         
+        var emojiString: EmojiString = .init()
+        
         var showCompleteButton: Bool = false
         var showDeletePopupView: Bool = false
     }
@@ -124,13 +126,18 @@ class RetrospectionStore: IntentStore {
             newState.originalMemo = memo.originalText
             if let retrospection = memo.originalRetrospectionText { newState.inputContent = retrospection }
             newState.createdDate = memo.createdAt.toFormattedDateTimeString()
-        case .updateRetrospection(let text): newState.inputContent = text
+        case .updateRetrospection(let text):
+            newState.inputContent = text
+        case .saveRetrospection:
+            newState.emojiString.syncWithNewString(newState.inputContent ?? "")
+            newState.emojiString.setUnassignedEmojis()
+            saveRetrospection(newState)
+        case .deleteRetrospection:
+            deleteRetrospection(newState)
+            
         case .showCompleteButton: newState.showCompleteButton = true
         case .hideCompleteButton: newState.showCompleteButton = false
-            
-        case .saveRetrospection: saveRetrospection(newState)
-        case .deleteRetrospection: deleteRetrospection(newState)
-            
+         
         case .showDeletePopupView: newState.showDeletePopupView = true
         case .hideDeletePopupView: newState.showDeletePopupView = false
         case .popToLast: router.pop()
@@ -144,7 +151,8 @@ class RetrospectionStore: IntentStore {
 extension RetrospectionStore {
     private func saveRetrospection(_ state: State) {
         let content = state.inputContent?.isEmpty == true ? nil : state.inputContent
-        let updatedmemo = memo.with(originalRetrospectionText: content, emojiRetrospectionText: "🍀🎉🥰")
+        let updatedmemo = memo.with(originalRetrospectionText: content,
+                                    emojiRetrospectionText: state.emojiString.getEmojiString())
         
         switch repository.save(memo: updatedmemo) {
         case .success:


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### 🔖 Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- close #48 

<br>

### 📚 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->
회고 관련 QA 사항 이슈를 수정했습니다. 

✅ 회고 내용이 메모 내용과 같은 이모지로 표현됨 (해결)
✅ 메모 내용 수정하면 회고도 같이 조정됨 (해결)


기존 `MemoCell` 에서 해당 부분이 `memo.emojiText`로 되어있어서 위와 같은 QA 사항이 발생했습니다. 
따라서 Memo 데이터 내에 `emojiRetrospectionText`라는 어트리뷰트를 추가하여 memo의 `emojiText`와 구분될 수 있도록 하였습니다. 
https://github.com/HorangITBeanS/COMFIE-iOS/blob/06da337a1543b2a1372b0edbb006c3f47f35d9f0/COMFIE/Presentation/Memo/MemoCell.swift#L74-L81

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇

-->

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->
작업하다가 실수로 develop 브랜치에 push를 해버렸습니다 ㅠ revert 해두었어요.
앞으로 유의해서 작업하겠습니닷..


<br>
