### PR TITLE
Fix: 실시간 위치에 따른 ComfieZone 설정 화면 데이터 반영

### DIFF
--- a/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneConstant.swift
+++ b/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneConstant.swift
@@ -10,7 +10,7 @@ import MapKit
 
 struct ComfieZoneConstant {
     static let mapRadiusInMeters: (latitude: CLLocationDistance, longitude: CLLocationDistance) = (200, 200) // 지도 반경
-    static let comfieZoneRadius: CLLocationDistance = 10.0  // 컴피존 반경
+    static let comfieZoneRadius: CLLocationDistance = 50.0  // 컴피존 반경
     static let defaultPosition = CLLocationCoordinate2D(  // 정자역
         latitude: 37.3663000,
         longitude: 127.1083000

--- a/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneConstant.swift
+++ b/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneConstant.swift
@@ -10,7 +10,7 @@ import MapKit
 
 struct ComfieZoneConstant {
     static let mapRadiusInMeters: (latitude: CLLocationDistance, longitude: CLLocationDistance) = (200, 200) // 지도 반경
-    static let comfieZoneRadius: CLLocationDistance = 50.0  // 컴피존 반경
+    static let comfieZoneRadius: CLLocationDistance = 10.0  // 컴피존 반경
     static let defaultPosition = CLLocationCoordinate2D(  // 정자역
         latitude: 37.3663000,
         longitude: 127.1083000

--- a/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingStore.swift
+++ b/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingStore.swift
@@ -82,6 +82,9 @@ class ComfieZoneSettingStore: IntentStore {
         case updateComfieZoneNameTextField(String)
         case checkButtonTapped
         case xButtonTapped
+        
+        // update
+        case updateAllStatesByNewCurrentLocation
     }
     
     enum Action {
@@ -130,6 +133,20 @@ class ComfieZoneSettingStore: IntentStore {
                         popupIntent(.closeDeleteComfieZonePopup)
                     }
                 }
+            }
+        case .updateAllStatesByNewCurrentLocation:
+            let isLocationAuthorized = getLocationAuthStatus()
+            let comfieZone = comfieZoneRepository.fetchComfieZone()
+            
+            if let comfieZone {
+                state = createStateWithComfieZone(
+                    comfieZone,
+                    isLocationAuthorized: isLocationAuthorized
+                )
+            } else {
+                state = createInitialStateWithoutComfieZone(
+                    isLocationAuthorized: isLocationAuthorized
+                )
             }
         }
     }

--- a/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingStore.swift
+++ b/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingStore.swift
@@ -83,7 +83,7 @@ class ComfieZoneSettingStore: IntentStore {
         case checkButtonTapped
         case xButtonTapped
         
-        // update
+        // Update State
         case updateAllStatesByNewCurrentLocation
     }
     
@@ -139,14 +139,9 @@ class ComfieZoneSettingStore: IntentStore {
             let comfieZone = comfieZoneRepository.fetchComfieZone()
             
             if let comfieZone {
-                state = createStateWithComfieZone(
-                    comfieZone,
-                    isLocationAuthorized: isLocationAuthorized
-                )
+                state = createStateWithComfieZone(comfieZone, isLocationAuthorized: isLocationAuthorized)
             } else {
-                state = createInitialStateWithoutComfieZone(
-                    isLocationAuthorized: isLocationAuthorized
-                )
+                state = createInitialStateWithoutComfieZone(isLocationAuthorized: isLocationAuthorized)
             }
         }
     }
@@ -221,7 +216,7 @@ class ComfieZoneSettingStore: IntentStore {
             latitude: comfieZone.latitude,
             longitude: comfieZone.longitude
         )
-        var userLocationCoordinate: CLLocationCoordinate2D? = nil
+        var userLocationCoordinate: CLLocationCoordinate2D?
         var isInComfieZone = false
         
         if isLocationAuthorized,

--- a/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingView.swift
+++ b/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingView.swift
@@ -86,7 +86,11 @@ struct ComfieZoneSettingView: View {
         .toolbar(.hidden, for: .navigationBar)  // 기본 네비게이션바 삭제
         .onChange(of: intent.currentLocation) { _, newValue in
             guard let newValue else { return }
-            intent(.updateAllStatesByNewCurrentLocation)
+            
+            if state.comfieZone != nil {
+                intent(.updateAllStatesByNewCurrentLocation)
+            }
+            
             withAnimation {
                 updateCameraPosition()
                 coordinater = newValue.coordinate

--- a/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingView.swift
+++ b/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingView.swift
@@ -28,7 +28,7 @@ struct ComfieZoneSettingView: View {
                             latitude: state.comfieZone?.latitude ?? 30,
                             longitude: state.comfieZone?.longitude ?? 30
                         ),
-                        radius: CLLocationDistance(50)
+                        radius: CLLocationDistance(ComfieZoneConstant.comfieZoneRadius)
                     )
                     .foregroundStyle(.keyPrimary.opacity(0.2))
                     .mapOverlayLevel(level: .aboveLabels)
@@ -86,6 +86,7 @@ struct ComfieZoneSettingView: View {
         .toolbar(.hidden, for: .navigationBar)  // 기본 네비게이션바 삭제
         .onChange(of: intent.currentLocation) { _, newValue in
             guard let newValue else { return }
+            intent(.updateAllStatesByNewCurrentLocation)
             withAnimation {
                 updateCameraPosition()
                 coordinater = newValue.coordinate


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### 🔖 Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- close #50 

<br>

### 📚 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

location 정보가 변경될 때마다 컴피존 여부와 현재 위치에 따른
1. 위치 권한 없음
2. 컴피존 없음
3. 컴피존 안에 있음
4. 컴피존 밖에 있음
이 네 가지 경우 중 하나로 판단하여 새로운 State를 생성하도록 반영했습니다.

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->

https://github.com/user-attachments/assets/af03a8fa-01a1-49d6-b540-fe4db56eb9c2


<br>