### PR TITLE
🐛 Fix: ComfieZone 설정 화면에서 발생하는 오류 해결

### DIFF
--- a/COMFIE/Domain/UseCase/LocationUseCase.swift
+++ b/COMFIE/Domain/UseCase/LocationUseCase.swift
@@ -48,4 +48,8 @@ class LocationUseCase {
             return false
         }
     }
+    
+    func triggerLocationUpdate() {
+        locationService.sendLocationToSubscriber()
+    }
 }

--- a/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingStore.swift
+++ b/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingStore.swift
@@ -32,17 +32,10 @@ class ComfieZoneSettingStore: IntentStore {
         self.popupIntent = popupIntent
         self.locationUseCase = locationUseCase
         self.comfieZoneRepository = comfieZoneRepository
-        
-        let isLocationAuthorized = self.getLocationAuthStatus()  // 위치 권한 여부
-        let comfieZone = comfieZoneRepository.fetchComfieZone()  // 컴피존
-        
-        if let comfieZone {
-            // 컴피존 있음 > 나의 위치로 지도 고정, 위치 권한 사라지면 컴피존 위치로 고정
-            self.state = createStateWithComfieZone(comfieZone, isLocationAuthorized: isLocationAuthorized)
-        } else {
-            // 컴피존 없음 > 초기 위치 설정
-            self.state = createInitialStateWithoutComfieZone(isLocationAuthorized: isLocationAuthorized)
-        }
+
+        // 초기 위치, 컴피존 설정
+        currentLocation = locationUseCase.getCurrentLocation()
+        handleIntent(.updateAllStatesByNewCurrentLocation)
         
         // subscribe to currentLocationPublisher
         locationUseCase.currentLocationPublisher

--- a/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingStore.swift
+++ b/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingStore.swift
@@ -101,9 +101,10 @@ class ComfieZoneSettingStore: IntentStore {
             }
         case .updateComfieZoneNameTextField(let text):
             state.newComfiezoneName = text
-        case .checkButtonTapped:
+        case .checkButtonTapped:  // 컴피존 추가
             withAnimation {
                 state = handleAction(state, .addComfieZone)
+                triggerCurrentLocationUpdate()
             }
         case .xButtonTapped:
             popupIntent(.openDeleteComfieZonePopup)
@@ -127,6 +128,7 @@ class ComfieZoneSettingStore: IntentStore {
                     }
                 }
             }
+            triggerCurrentLocationUpdate()
         case .updateAllStatesByNewCurrentLocation:
             let isLocationAuthorized = getLocationAuthStatus()
             let comfieZone = comfieZoneRepository.fetchComfieZone()
@@ -240,5 +242,9 @@ class ComfieZoneSettingStore: IntentStore {
             latitudinalMeters: ComfieZoneConstant.mapRadiusInMeters.latitude,  // 지도 반경
             longitudinalMeters: ComfieZoneConstant.mapRadiusInMeters.longitude
         )
+    }
+    
+    private func triggerCurrentLocationUpdate() {
+        locationUseCase.triggerLocationUpdate()
     }
 }

--- a/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingView.swift
+++ b/COMFIE/Presentation/ComfieZoneSetting/ComfieZoneSettingView.swift
@@ -98,6 +98,7 @@ struct ComfieZoneSettingView: View {
             rightButtonAction: { intent.popupIntent(.closeDeleteComfieZonePopup) }
         )
         .toolbar(.hidden, for: .navigationBar)  // 기본 네비게이션바 삭제
+        .onAppear { updateCameraPosition() }
         .onChange(of: intent.currentLocation) { _, newValue in
             guard let newValue else { return }
             
@@ -113,9 +114,13 @@ struct ComfieZoneSettingView: View {
     }
     
     private func updateCameraPosition() {
-        guard let location = intent.currentLocation else { return }
+        var mapLocationCoordinator = ComfieZoneConstant.defaultPosition
+        if let currentLocationCoordinator = intent.currentLocation?.coordinate {
+            mapLocationCoordinator = currentLocationCoordinator
+        }
+        
         let region = MKCoordinateRegion(
-            center: location.coordinate,
+            center: mapLocationCoordinator,
             latitudinalMeters: ComfieZoneConstant.mapRadiusInMeters.latitude,
             longitudinalMeters: ComfieZoneConstant.mapRadiusInMeters.longitude
         )

--- a/COMFIE/Service/LocationService.swift
+++ b/COMFIE/Service/LocationService.swift
@@ -54,6 +54,20 @@ class LocationService: NSObject, CLLocationManagerDelegate {
     // 위치 권한 변경 시 요청되는 메서드
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
         self.authorizationStatus = status
+        
+        switch status {
+        case .authorizedWhenInUse, .authorizedAlways:
+            manager.startUpdatingLocation()
+            // 캐시된 위치가 있으면 즉시 설정
+            if let cachedLocation = manager.location {
+                currentLocation = cachedLocation
+            }
+        case .denied, .restricted:
+            manager.stopUpdatingLocation()
+            currentLocation = nil
+        default:
+            break
+        }
     }
     
     // 위치 변경 시 요청되는 메서드

--- a/COMFIE/Service/LocationService.swift
+++ b/COMFIE/Service/LocationService.swift
@@ -89,4 +89,9 @@ class LocationService: NSObject, CLLocationManagerDelegate {
             longitudinalMeters: ComfieZoneConstant.mapRadiusInMeters.longitude
         )
     }
+    
+    func sendLocationToSubscriber() {
+        guard let location = currentLocation else { return }
+        currentLocationSubject.send(location)
+    }
 }


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: ✨ Feat: #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### 🔖 Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- close #53 

<br>

### 📚 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

마케팅 일정 전, 현재 배포 버전에서 발생하는 컴피존 관련 문제를 해결했습니다.
> **[발견된 문제]**
> 1. 앱을 처음 사용할 때 "현재위치 = 정자역" 으로 인식돼요.
> 2. "세계지도"가 처음에 뜨고 줌인돼서 "현재 위치"로 이동해요

**1. ComfieZoneView에 처음 진입할 때 위치 인식 오류**
- 처음 ComfieZoneView에 들어올 때 현재 위치를 잘 받아오는가? -> No
  View의 onAppear 단계에서 currentLocation을 출력했을 때 nil을 반환하고 있었습니다.
  이에 **ComfieZoneSettingStore init 단계에서 currentLocation을 할당**하는 과정을 추가했습니다.
- 현재 위치 잘 받아옴. 그럼 이제 세계지도가 뜨는 문제가 해결되었는가? -> No
  현재 위치를 nil이 아닌 상태로 잘 받아옴에도 불구하고, 지도 문제가 해결되지 않았습니다.
  Map의 cameraPosition의 문제라고 판단하고 파악한 결과,
  처음 화면이 생성될 때 cameraPostion 값이 설정되지 않는 상황이었습니다.
  이에 **onAppear 에서 cameraPostion을 업데이트**해주었습니다.
- 2번 문제 해결 !!

**2. 앱 최초 설치 시 위치 인식 오류**
- 화면 초기 진입 시 위치 인식 오류를 해결했음. 앱 최초 설치 위치 오류도 해결되었나? -> No.
  위치 인식 문제와 별개로 최초 설치 문제를 바라보았습니다.
- 2회차 실행과 최초 실행의 다른 점이 무엇인가?
  앱 최초 설치 시에는 다른 때와 다르게 앱 실행 과정 내에서 위치 권한 설정을 하는 단계가 있습니다.
  따라서 권한 설정과 관련된 문제라고 생각하고 파악한 결과,
  위치 권한이 변경되더라도 위치를 가져오는 과정이 빠져있었습니다.
  **위치 권한 변경 후, 변경된 권한에 따라 적절하게 위치를 인식하거나 위치 인식을 멈추는 과정을 추가**했습니다.
- 1번 문제 해결 !!

**3. 컴피존 안팎 여부 인식 오류**
- 모든 실행이 정상적으로 작동하는가? -> No
  발견된 오류가 모두 해결되고, 다른 동작에 문제가 없는지 확인했습니다.
  하지만 이전에 한 번 언급되었던, 컴피존 설정 후 메모 화면에서 컴피존 안팎 여부를 인식하지 못하는 문제가 다시 발생했습니다.
- 메모 store에서 컴피존 여부를 파악하는 방법은?
  해당 내용 파악 결과, location publisher에 의존하고 있었습니다.
  사실 이 내용은 ComfieZone 변경 여부를 전달하는 Publisher를 별개로 두는 것이 맞다고 생각하나,
  우선 빠르게 문제를 해결하기 위해 ComfieZone 변경사항이 생겼을 때,
  location을 현재위치로 재설정하는 과정을 추가했습니다.
- 일단.. 해결..!

<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->

영상 용량 문제로 코멘트에 남기겠습니다!

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->


<br>
